### PR TITLE
feat: get_loggerメソッドでWorkspace連携ロガーを追加

### DIFF
--- a/pochi/__init__.py
+++ b/pochi/__init__.py
@@ -1,7 +1,8 @@
 """Pochi - A versatile method collection for Python."""
 
+from .logging import ILoggerFactory
 from .pochi import Pochi
 from .workspace import IWorkspaceCreator, Workspace
 
 __version__ = "0.0.1"
-__all__ = ["IWorkspaceCreator", "Pochi", "Workspace"]
+__all__ = ["ILoggerFactory", "IWorkspaceCreator", "Pochi", "Workspace"]

--- a/pochi/logging/__init__.py
+++ b/pochi/logging/__init__.py
@@ -1,0 +1,6 @@
+"""Logging package."""
+
+from .factory import LoggerFactory
+from .interfaces import ILoggerFactory
+
+__all__ = ["ILoggerFactory", "LoggerFactory"]

--- a/pochi/logging/factory.py
+++ b/pochi/logging/factory.py
@@ -1,0 +1,66 @@
+"""Logging factory module.
+
+ロガー生成の実装.
+"""
+
+import logging
+from pathlib import Path
+
+from .handlers import create_console_handler, create_file_handler
+from .interfaces import ILoggerFactory
+
+
+class LoggerFactory(ILoggerFactory):
+    """ロガー生成の実装クラス.
+
+    コンソール出力（色付き）とファイル出力（プレーン）を提供.
+    """
+
+    # 生成済みロガーのキャッシュ
+    _loggers: dict[str, logging.Logger] = {}
+
+    def create(
+        self,
+        name: str,
+        log_dir: str | Path | None = None,
+        level: int = logging.INFO,
+    ) -> logging.Logger:
+        """ロガーを生成.
+
+        Args:
+            name: ロガー名.
+            log_dir: ログファイル出力先ディレクトリ. Noneの場合はコンソールのみ.
+            level: ログレベル.
+
+        Returns:
+            設定済みのロガー.
+        """
+        # キャッシュキーを生成
+        cache_key = f"{name}:{log_dir}"
+
+        # 既に生成済みなら返す
+        if cache_key in self._loggers:
+            return self._loggers[cache_key]
+
+        # ロガーを生成
+        logger = logging.getLogger(name)
+        logger.setLevel(level)
+
+        # 既存のハンドラーをクリア（重複防止）
+        logger.handlers.clear()
+
+        # コンソールハンドラーを追加
+        logger.addHandler(create_console_handler(level))
+
+        # ファイルハンドラーを追加（log_dirが指定された場合）
+        if log_dir is not None:
+            log_path = Path(log_dir) / f"{name.replace('.', '_')}.log"
+            logger.addHandler(create_file_handler(log_path, level))
+
+        # 親ロガーへの伝播を無効化
+        logger.propagate = False
+
+        # キャッシュに保存
+        self._loggers[cache_key] = logger
+
+        return logger

--- a/pochi/logging/formatters.py
+++ b/pochi/logging/formatters.py
@@ -1,0 +1,67 @@
+"""Logging formatters module.
+
+ログフォーマッターの定義.
+"""
+
+import logging
+
+# デフォルトのログフォーマット
+DEFAULT_FORMAT = "%(asctime)s | %(levelname)-8s | %(name)s | %(message)s"
+DEFAULT_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+# カラーコード
+COLORS = {
+    "DEBUG": "\033[36m",  # シアン
+    "INFO": "\033[32m",  # 緑
+    "WARNING": "\033[33m",  # 黄
+    "ERROR": "\033[31m",  # 赤
+    "CRITICAL": "\033[35m",  # マゼンタ
+}
+RESET = "\033[0m"
+
+
+class ColoredFormatter(logging.Formatter):
+    """色付きログフォーマッター.
+
+    コンソール出力用にログレベルに応じた色を付与.
+    """
+
+    def __init__(
+        self,
+        fmt: str = DEFAULT_FORMAT,
+        datefmt: str = DEFAULT_DATE_FORMAT,
+    ) -> None:
+        """ColoredFormatterを初期化."""
+        super().__init__(fmt, datefmt)
+
+    def format(self, record: logging.LogRecord) -> str:
+        """ログレコードをフォーマット."""
+        # 元のlevelname を保存
+        original_levelname = record.levelname
+
+        # 色を付与
+        color = COLORS.get(record.levelname, "")
+        record.levelname = f"{color}{record.levelname}{RESET}"
+
+        # フォーマット
+        result = super().format(record)
+
+        # 元に戻す
+        record.levelname = original_levelname
+
+        return result
+
+
+class PlainFormatter(logging.Formatter):
+    """プレーンテキストフォーマッター.
+
+    ファイル出力用に色なしのフォーマット.
+    """
+
+    def __init__(
+        self,
+        fmt: str = DEFAULT_FORMAT,
+        datefmt: str = DEFAULT_DATE_FORMAT,
+    ) -> None:
+        """PlainFormatterを初期化."""
+        super().__init__(fmt, datefmt)

--- a/pochi/logging/handlers.py
+++ b/pochi/logging/handlers.py
@@ -1,0 +1,44 @@
+"""Logging handlers module.
+
+ログハンドラーの生成関数.
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+from .formatters import ColoredFormatter, PlainFormatter
+
+
+def create_console_handler(level: int = logging.INFO) -> logging.StreamHandler:
+    """色付きコンソールハンドラーを生成.
+
+    Args:
+        level: ログレベル.
+
+    Returns:
+        設定済みのStreamHandler.
+    """
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(level)
+    handler.setFormatter(ColoredFormatter())
+    return handler
+
+
+def create_file_handler(
+    log_path: Path,
+    level: int = logging.INFO,
+) -> logging.FileHandler:
+    """ファイルハンドラーを生成.
+
+    Args:
+        log_path: ログファイルのパス.
+        level: ログレベル.
+
+    Returns:
+        設定済みのFileHandler.
+    """
+    handler = logging.FileHandler(log_path, encoding="utf-8")
+    handler.setLevel(level)
+    handler.setFormatter(PlainFormatter())
+    return handler

--- a/pochi/logging/interfaces.py
+++ b/pochi/logging/interfaces.py
@@ -1,0 +1,31 @@
+"""Logging interfaces module.
+
+ロガー関連のインターフェース定義.
+"""
+
+import logging
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+
+class ILoggerFactory(ABC):
+    """ロガー生成のインターフェース."""
+
+    @abstractmethod
+    def create(
+        self,
+        name: str,
+        log_dir: str | Path | None = None,
+        level: int = logging.INFO,
+    ) -> logging.Logger:
+        """ロガーを生成.
+
+        Args:
+            name: ロガー名.
+            log_dir: ログファイル出力先ディレクトリ. Noneの場合はコンソールのみ.
+            level: ログレベル.
+
+        Returns:
+            設定済みのロガー.
+        """
+        ...

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,159 @@
+"""Tests for Logging functionality."""
+
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from pochi import ILoggerFactory, Pochi
+from pochi.logging import LoggerFactory
+from pochi.logging.formatters import ColoredFormatter, PlainFormatter
+from pochi.logging.handlers import create_console_handler, create_file_handler
+
+
+class TestFormatters:
+    """フォーマッタークラスのテスト."""
+
+    def test_colored_formatter_adds_color(self) -> None:
+        """ColoredFormatterが色コードを追加することを確認."""
+        formatter = ColoredFormatter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="test message",
+            args=(),
+            exc_info=None,
+        )
+
+        result = formatter.format(record)
+
+        # 色コードが含まれていることを確認
+        assert "\033[" in result
+        assert "test message" in result
+
+    def test_plain_formatter_no_color(self) -> None:
+        """PlainFormatterが色コードを追加しないことを確認."""
+        formatter = PlainFormatter()
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="test message",
+            args=(),
+            exc_info=None,
+        )
+
+        result = formatter.format(record)
+
+        # 色コードが含まれていないことを確認
+        assert "\033[" not in result
+        assert "test message" in result
+
+
+class TestHandlers:
+    """ハンドラー生成関数のテスト."""
+
+    def test_create_console_handler(self) -> None:
+        """コンソールハンドラーが生成されることを確認."""
+        handler = create_console_handler()
+
+        assert isinstance(handler, logging.StreamHandler)
+        assert isinstance(handler.formatter, ColoredFormatter)
+
+    def test_create_file_handler(self, tmp_path: Path) -> None:
+        """ファイルハンドラーが生成されることを確認."""
+        log_path = tmp_path / "test.log"
+        handler = create_file_handler(log_path)
+
+        assert isinstance(handler, logging.FileHandler)
+        assert isinstance(handler.formatter, PlainFormatter)
+
+
+class TestLoggerFactory:
+    """LoggerFactoryクラスのテスト."""
+
+    def test_create_console_only(self) -> None:
+        """コンソールのみのロガーが生成されることを確認."""
+        factory = LoggerFactory()
+
+        logger = factory.create("test_console")
+
+        assert isinstance(logger, logging.Logger)
+        assert len(logger.handlers) == 1
+        assert isinstance(logger.handlers[0], logging.StreamHandler)
+
+    def test_create_with_file(self, tmp_path: Path) -> None:
+        """ファイル出力付きロガーが生成されることを確認."""
+        factory = LoggerFactory()
+
+        logger = factory.create("test_file", log_dir=tmp_path)
+
+        assert len(logger.handlers) == 2
+        # コンソールハンドラー
+        assert isinstance(logger.handlers[0], logging.StreamHandler)
+        # ファイルハンドラー
+        assert isinstance(logger.handlers[1], logging.FileHandler)
+
+    def test_create_writes_to_file(self, tmp_path: Path) -> None:
+        """ロガーがファイルに書き込むことを確認."""
+        factory = LoggerFactory()
+        logger = factory.create("test_write", log_dir=tmp_path)
+
+        logger.info("test message")
+
+        log_file = tmp_path / "test_write.log"
+        assert log_file.exists()
+        content = log_file.read_text()
+        assert "test message" in content
+
+    def test_create_returns_cached_logger(self) -> None:
+        """同じ設定で同じロガーが返されることを確認."""
+        factory = LoggerFactory()
+
+        logger1 = factory.create("test_cache")
+        logger2 = factory.create("test_cache")
+
+        assert logger1 is logger2
+
+
+class TestPochiGetLogger:
+    """Pochi.get_loggerメソッドのテスト."""
+
+    def test_get_logger_console_only(self) -> None:
+        """コンソールのみのロガーが取得できることを確認."""
+        pochi = Pochi()
+
+        logger = pochi.get_logger("test_pochi")
+
+        assert isinstance(logger, logging.Logger)
+
+    def test_get_logger_with_workspace(self, tmp_path: Path) -> None:
+        """Workspaceと連携したロガーが取得できることを確認."""
+        pochi = Pochi()
+        ws = pochi.create_workspace(tmp_path, subdirs=["logs"])
+
+        logger = pochi.get_logger("test_ws", ws.logs)
+        logger.info("workspace log test")
+
+        log_file = ws.logs / "test_ws.log"
+        assert log_file.exists()
+        content = log_file.read_text()
+        assert "workspace log test" in content
+
+    def test_get_logger_with_mock_factory(self) -> None:
+        """カスタムLoggerFactoryを注入できることを確認."""
+        mock_factory = MagicMock(spec=ILoggerFactory)
+        mock_logger = MagicMock(spec=logging.Logger)
+        mock_factory.create.return_value = mock_logger
+
+        pochi = Pochi(logger_factory=mock_factory)
+        result = pochi.get_logger("test", level=logging.DEBUG)
+
+        assert result == mock_logger
+        mock_factory.create.assert_called_once_with(
+            "test", log_dir=None, level=logging.DEBUG
+        )


### PR DESCRIPTION
## 概要

- `Pochi.get_logger()`メソッドを実装
  - コンソール出力（色付き）
  - Workspaceと連携してファイル出力（プレーンテキスト）
- `logging/`パッケージを追加
  - `ILoggerFactory`: ロガー生成のインターフェース
  - `LoggerFactory`: 実装（キャッシュ機能付き）
  - `ColoredFormatter`: コンソール用色付きフォーマッター
  - `PlainFormatter`: ファイル用プレーンフォーマッター
- CLAUDE.mdを追加

## テスト計画

- [ ] `uv run pytest`で全テストがパスすることを確認
- [ ] コンソールのみ/ファイル出力ありの動作確認