### PR TITLE
feat: Pochiクラスにtimerメソッドを追加

### DIFF
--- a/pochi/__init__.py
+++ b/pochi/__init__.py
@@ -2,7 +2,8 @@
 
 from .logging import ILoggerFactory
 from .pochi import Pochi
+from .timer import ITimerFactory
 from .workspace import IWorkspaceCreator, Workspace
 
 __version__ = "0.0.1"
-__all__ = ["ILoggerFactory", "IWorkspaceCreator", "Pochi", "Workspace"]
+__all__ = ["ILoggerFactory", "ITimerFactory", "IWorkspaceCreator", "Pochi", "Workspace"]

--- a/pochi/timer/__init__.py
+++ b/pochi/timer/__init__.py
@@ -1,0 +1,6 @@
+"""Timer package."""
+
+from .interfaces import ITimerFactory
+from .timer import TimerContext, TimerFactory
+
+__all__ = ["ITimerFactory", "TimerContext", "TimerFactory"]

--- a/pochi/timer/interfaces.py
+++ b/pochi/timer/interfaces.py
@@ -1,0 +1,28 @@
+"""Timer interfaces module.
+
+タイマー関連のインターフェース定義.
+"""
+
+import logging
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .timer import TimerContext
+
+
+class ITimerFactory(ABC):
+    """タイマー生成のインターフェース."""
+
+    @abstractmethod
+    def create(self, name: str, logger: logging.Logger | None = None) -> "TimerContext":
+        """タイマーコンテキストを生成.
+
+        Args:
+            name: タイマー名（ログ出力時に使用）.
+            logger: ログ出力先. Noneの場合はprint出力.
+
+        Returns:
+            コンテキストマネージャーとして使用可能なタイマー.
+        """
+        ...

--- a/pochi/timer/timer.py
+++ b/pochi/timer/timer.py
@@ -1,0 +1,73 @@
+"""Timer implementation module.
+
+タイマーの実装.
+"""
+
+import logging
+import time
+from types import TracebackType
+
+from .interfaces import ITimerFactory
+
+
+class TimerContext:
+    """タイマーコンテキストマネージャー.
+
+    処理時間を計測し、終了時にログ出力.
+
+    Args:
+        name: タイマー名.
+        logger: ログ出力先. Noneの場合はprint出力.
+    """
+
+    def __init__(self, name: str, logger: logging.Logger | None = None) -> None:
+        """TimerContextを初期化."""
+        self._name = name
+        self._logger = logger
+        self._start_time: float = 0.0
+        self._elapsed: float = 0.0
+
+    def __enter__(self) -> "TimerContext":
+        """コンテキスト開始時に呼ばれる."""
+        self._start_time = time.perf_counter()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """コンテキスト終了時に呼ばれる."""
+        self._elapsed = time.perf_counter() - self._start_time
+        message = f"{self._name}: {self._elapsed:.3f}s"
+
+        if self._logger is not None:
+            self._logger.info(message)
+        else:
+            print(message)
+
+    @property
+    def elapsed(self) -> float:
+        """経過時間（秒）を取得."""
+        return self._elapsed
+
+
+class TimerFactory(ITimerFactory):
+    """タイマー生成の実装クラス."""
+
+    def create(
+        self,
+        name: str,
+        logger: logging.Logger | None = None,
+    ) -> TimerContext:
+        """タイマーコンテキストを生成.
+
+        Args:
+            name: タイマー名（ログ出力時に使用）.
+            logger: ログ出力先. Noneの場合はprint出力.
+
+        Returns:
+            コンテキストマネージャーとして使用可能なタイマー.
+        """
+        return TimerContext(name, logger=logger)

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -1,0 +1,109 @@
+"""Tests for Timer functionality."""
+
+import logging
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from pochi import ITimerFactory, Pochi
+from pochi.timer import TimerContext, TimerFactory
+
+
+class TestTimerContext:
+    """TimerContextクラスのテスト."""
+
+    def test_measures_elapsed_time(self) -> None:
+        """経過時間が計測されることを確認."""
+        timer = TimerContext("test")
+
+        with timer:
+            time.sleep(0.1)
+
+        assert timer.elapsed >= 0.1
+        assert timer.elapsed < 0.2
+
+    def test_prints_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """print出力されることを確認."""
+        with TimerContext("処理A"):
+            time.sleep(0.05)
+
+        captured = capsys.readouterr()
+        assert "処理A:" in captured.out
+        assert "s" in captured.out
+
+    def test_logs_output(self) -> None:
+        """ロガー経由で出力されることを確認."""
+        mock_logger = MagicMock(spec=logging.Logger)
+
+        with TimerContext("処理B", logger=mock_logger):
+            time.sleep(0.05)
+
+        mock_logger.info.assert_called_once()
+        call_args = mock_logger.info.call_args[0][0]
+        assert "処理B:" in call_args
+
+
+class TestTimerFactory:
+    """TimerFactoryクラスのテスト."""
+
+    def test_create_returns_timer_context(self) -> None:
+        """TimerContextが返されることを確認."""
+        factory = TimerFactory()
+
+        timer = factory.create("test")
+
+        assert isinstance(timer, TimerContext)
+
+    def test_create_with_logger(self) -> None:
+        """ロガー付きでTimerContextが生成されることを確認."""
+        factory = TimerFactory()
+        mock_logger = MagicMock(spec=logging.Logger)
+
+        with factory.create("test", logger=mock_logger):
+            pass
+
+        mock_logger.info.assert_called_once()
+
+
+class TestPochiTimer:
+    """Pochi.timerメソッドのテスト."""
+
+    def test_timer_returns_context_manager(self) -> None:
+        """コンテキストマネージャーが返されることを確認."""
+        pochi = Pochi()
+
+        timer = pochi.timer("test")
+
+        assert isinstance(timer, TimerContext)
+
+    def test_timer_measures_time(self) -> None:
+        """時間が計測されることを確認."""
+        pochi = Pochi()
+
+        with pochi.timer("test") as t:
+            time.sleep(0.1)
+
+        assert t.elapsed >= 0.1
+
+    def test_timer_with_logger(self) -> None:
+        """ロガーと連携できることを確認."""
+        pochi = Pochi()
+        mock_logger = MagicMock(spec=logging.Logger)
+
+        with pochi.timer("test", logger=mock_logger):
+            pass
+
+        mock_logger.info.assert_called_once()
+
+    def test_timer_with_mock_factory(self) -> None:
+        """カスタムTimerFactoryを注入できることを確認."""
+        mock_factory = MagicMock(spec=ITimerFactory)
+        mock_timer = MagicMock(spec=TimerContext)
+        mock_factory.create.return_value = mock_timer
+
+        pochi = Pochi(timer_factory=mock_factory)
+        result = pochi.timer("test")
+
+        assert result == mock_timer
+        mock_factory.create.assert_called_once_with("test", logger=None)


### PR DESCRIPTION
## 概要

- `Pochi.timer()`メソッドを実装
  - コンテキストマネージャーで処理時間を計測
  - print出力（デフォルト）またはロガー経由で出力
  - `elapsed`プロパティで経過時間を取得可能
- `timer/`パッケージを追加
  - `ITimerFactory`: タイマー生成のインターフェース
  - `TimerFactory`: 実装
  - `TimerContext`: コンテキストマネージャー

## テスト計画

- [ ] `uv run pytest`で全テストがパスすることを確認
- [ ] print出力/ロガー連携の動作確認