### PR TITLE
docs: PythonConfigLoader のセキュリティ警告を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,24 @@ logger.warning("学習率が低すぎる可能性があります")
 logger.error("学習に失敗しました")
 ```
 
+### Config
+
+Python 設定ファイル (.py) を読み込み、Pydantic モデルでバリデーションします。
+
+```python
+from pydantic import BaseModel
+
+class TrainConfig(BaseModel):
+    model_name: str
+    epochs: int
+    learning_rate: float = 0.001
+
+config = pochi.load_config("config.py", TrainConfig)
+print(config.epochs)  # 100
+```
+
+> **⚠️ セキュリティ警告**: `load_config` は Python ファイルを実行するため、信頼できないソースからの設定ファイルを読み込むと任意コード実行のリスクがあります。自分で作成した設定ファイル、またはコードレビュー済みのファイルのみを使用してください。
+
 ### Timer
 
 コンテキストマネージャーで処理時間を計測します。

--- a/pochi/config/python_loader.py
+++ b/pochi/config/python_loader.py
@@ -12,6 +12,12 @@ class PythonConfigLoader(IConfigLoader):
 
     .py ファイル内のモジュールレベル変数を dict として取得する.
 
+    Warning:
+        このローダーは Python ファイルを実行するため, 信頼できないソースからの
+        設定ファイルを読み込むと任意コード実行のリスクがあります.
+        自分で作成した設定ファイル, またはコードレビュー済みのファイルのみを
+        使用してください.
+
     Example:
         >>> loader = PythonConfigLoader()
         >>> config = loader.load("config.py")


### PR DESCRIPTION
## Summary

- PythonConfigLoader の docstring にセキュリティ警告を追加
- README に Config セクションとセキュリティ警告を追加

## 変更内容

- `PythonConfigLoader` の docstring に Warning セクションを追加
- README に `load_config` の使用例とセキュリティ警告を追加

## Test plan

- [x] pre-commit 全パス (black, isort, mypy, pydocstyle, pytest)