### PR TITLE
fix: FileHandler 作成前にログディレクトリを自動作成

### DIFF
--- a/pochi/logging/handlers.py
+++ b/pochi/logging/handlers.py
@@ -38,6 +38,9 @@ def create_file_handler(
     Returns:
         設定済みのFileHandler.
     """
+    # 親ディレクトリが存在しない場合は作成
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
     handler = logging.FileHandler(log_path, encoding="utf-8")
     handler.setLevel(level)
     handler.setFormatter(PlainFormatter())


### PR DESCRIPTION
## Summary

- `create_file_handler` でログファイル作成前に親ディレクトリを自動作成
- `Workspace` を使わずに直接パスを指定した場合でもエラーにならない

## 変更内容

- `log_path.parent.mkdir(parents=True, exist_ok=True)` を追加
- これにより `pochi.get_logger("app", "my_logs")` のような使い方でも動作

## Test plan

- [x] pre-commit 全パス (black, isort, mypy, pydocstyle, pytest)