### PR TITLE
docs: README に FileOps セクションを追加し version を 0.0.2 に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,22 @@ print(config.epochs)  # 100
 
 > **⚠️ セキュリティ警告**: `load_config` は Python ファイルを実行するため、信頼できないソースからの設定ファイルを読み込むと任意コード実行のリスクがあります。自分で作成した設定ファイル、またはコードレビュー済みのファイルのみを使用してください。
 
+### FileOps
+
+ファイルの検索・コピー・移動を行います。階層構造を保持したコピーも可能です。
+
+```python
+# ファイル検索
+files = pochi.find_files("data/", pattern="**/*.jpg")
+
+# 階層構造を保持してコピー
+result = pochi.copy_files("data/", "backup/", pattern="**/*.jpg")
+# data/train/cat/001.jpg → backup/train/cat/001.jpg
+
+# 移動も同様
+result = pochi.move_files("temp/", "archive/", pattern="**/*.log")
+```
+
 ### Timer
 
 コンテキストマネージャーで処理時間を計測します。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pochimethod"
-version = "0.0.1"
+version = "0.0.2"
 description = "A versatile method collection for Python — Pochi's favorite bones, all in one place!"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "pochimethod"
-version = "0.0.1"
+version = "0.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- README に FileOps（find_files, copy_files, move_files）の使用例を追加
- pyproject.toml の version を 0.0.2 に更新

## 変更内容

- README.md: FileOps セクションを Timer の前に追加
- pyproject.toml: version を "0.0.1" → "0.0.2" に変更

## Test plan

- [x] pre-commit 全パス (black, isort, mypy, pydocstyle, pytest)