### PR TITLE
feat: Workspace に __dir__ を追加し IDE 補完を改善

### DIFF
--- a/pochi/workspace/models.py
+++ b/pochi/workspace/models.py
@@ -53,6 +53,13 @@ class Workspace:
             f"Available: {list(self._subdirs.keys())}"
         )
 
+    def __dir__(self) -> list[str]:
+        """利用可能な属性のリストを返す.
+
+        IDE 補完でサブディレクトリ名が表示されるようにする.
+        """
+        return list(super().__dir__()) + list(self._subdirs.keys())
+
     def __repr__(self) -> str:
         """文字列表現を返す."""
         return f"Workspace(root={self._root}, subdirs={list(self._subdirs.keys())})"


### PR DESCRIPTION
## Summary

- Workspace クラスに `__dir__` メソッドを追加
- IDE でサブディレクトリ名が補完候補に表示されるようになった

## 変更内容

- `__dir__` で通常の属性 + サブディレクトリ名を返すように実装
- `hasattr` は既に正しく動作していた（`__getattr__` が `AttributeError` を発生させていた）

## Test plan

- [x] pre-commit 全パス (black, isort, mypy, pydocstyle, pytest)
