### PR TITLE
feat: TimerContext で例外発生時に warning ログを出力

### DIFF
--- a/pochi/timer/timer.py
+++ b/pochi/timer/timer.py
@@ -40,12 +40,21 @@ class TimerContext:
     ) -> None:
         """コンテキスト終了時に呼ばれる."""
         self._elapsed = time.perf_counter() - self._start_time
-        message = f"{self._name}: {self._elapsed:.3f}s"
 
-        if self._logger is not None:
-            self._logger.info(message)
+        if exc_type is not None:
+            # 例外発生時
+            message = f"{self._name} (failed): {self._elapsed:.3f}s"
+            if self._logger is not None:
+                self._logger.warning(message)
+            else:
+                print(message)
         else:
-            print(message)
+            # 正常終了時
+            message = f"{self._name}: {self._elapsed:.3f}s"
+            if self._logger is not None:
+                self._logger.info(message)
+            else:
+                print(message)
 
     @property
     def elapsed(self) -> float:

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -43,6 +43,31 @@ class TestTimerContext:
         call_args = mock_logger.info.call_args[0][0]
         assert "処理B:" in call_args
 
+    def test_logs_warning_on_exception(self) -> None:
+        """例外発生時にwarningでログ出力されることを確認."""
+        mock_logger = MagicMock(spec=logging.Logger)
+
+        with pytest.raises(ValueError):
+            with TimerContext("処理C", logger=mock_logger):
+                raise ValueError("テストエラー")
+
+        mock_logger.warning.assert_called_once()
+        call_args = mock_logger.warning.call_args[0][0]
+        assert "処理C" in call_args
+        assert "failed" in call_args
+
+    def test_prints_failed_on_exception(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """例外発生時にfailedがprint出力されることを確認."""
+        with pytest.raises(ValueError):
+            with TimerContext("処理D"):
+                raise ValueError("テストエラー")
+
+        captured = capsys.readouterr()
+        assert "処理D" in captured.out
+        assert "failed" in captured.out
+
 
 class TestTimerFactory:
     """TimerFactoryクラスのテスト."""


### PR DESCRIPTION
## Summary

- TimerContext の `__exit__` で例外発生を検知
- 正常終了時は `INFO` レベル, 例外発生時は `WARNING` レベルでログ出力
- メッセージに `(failed)` を付与して区別可能に

## 動作

```
# 正常終了時
INFO: 処理: 1.234s

# 例外発生時
WARNING: 処理 (failed): 0.123s
```

## 変更内容

- `pochi/timer/timer.py`: `__exit__` で `exc_type` を判定し, ログレベルを切り替え
- `tests/test_timer.py`: 例外発生時のテストを追加

## Test plan

- [x] pre-commit 全パス (black, isort, mypy, pydocstyle, pytest)
- [x] 例外発生時に warning ログが出力されることを確認
- [x] print 出力時も (failed) が表示されることを確認
