### PR TITLE
feat: mirror_structure メソッドを追加

### DIFF
--- a/pochi/fileops/copier.py
+++ b/pochi/fileops/copier.py
@@ -143,3 +143,46 @@ class StructurePreservingCopier(IFileCopier):
 """
 
         metadata_path.write_text(content, encoding="utf-8")
+
+    def mirror_structure(
+        self,
+        files: list[Path],
+        dest: str | Path,
+        base_dir: str | Path | None = None,
+    ) -> tuple[list[Path], list[Path]]:
+        """フォルダ構造のみ作成し, 対応するパスを返す.
+
+        ファイルの中身はコピーせず, 出力先のフォルダ構造だけを作成する.
+
+        Args:
+            files: 対象のファイルリスト.
+            dest: 出力先ディレクトリ.
+            base_dir: 階層構造の基準ディレクトリ.
+
+        Returns:
+            (元ファイルパスリスト, 出力先ファイルパスリスト) のタプル.
+        """
+        dest_path = Path(dest)
+        base_path = Path(base_dir).resolve() if base_dir else None
+
+        src_files: list[Path] = []
+        dest_files: list[Path] = []
+
+        for src_file in files:
+            src_file = src_file.resolve()
+
+            if base_path:
+                try:
+                    rel_path = src_file.relative_to(base_path)
+                except ValueError:
+                    rel_path = Path(src_file.name)
+            else:
+                rel_path = Path(src_file.name)
+
+            dest_file = dest_path / rel_path
+            dest_file.parent.mkdir(parents=True, exist_ok=True)
+
+            src_files.append(src_file)
+            dest_files.append(dest_file)
+
+        return src_files, dest_files

--- a/pochi/fileops/interfaces.py
+++ b/pochi/fileops/interfaces.py
@@ -67,3 +67,25 @@ class IFileCopier(ABC):
             移動先のファイルパスリスト.
         """
         pass
+
+    @abstractmethod
+    def mirror_structure(
+        self,
+        files: list[Path],
+        dest: str | Path,
+        base_dir: str | Path | None = None,
+    ) -> tuple[list[Path], list[Path]]:
+        """フォルダ構造のみ作成し, 対応するパスを返す.
+
+        ファイルの中身はコピーせず, 出力先のフォルダ構造だけを作成する.
+        処理後のファイルを元と同じ構造で保存したい場合に便利.
+
+        Args:
+            files: 対象のファイルリスト.
+            dest: 出力先ディレクトリ.
+            base_dir: 階層構造の基準ディレクトリ.
+
+        Returns:
+            (元ファイルパスリスト, 出力先ファイルパスリスト) のタプル.
+        """
+        pass

--- a/pochi/pochi.py
+++ b/pochi/pochi.py
@@ -246,3 +246,34 @@ class Pochi:
             >>> pochi.move_files(files, dest="processed/", base_dir="data/")
         """
         return self._file_copier.move(files, dest, base_dir=base_dir)
+
+    def mirror_structure(
+        self,
+        files: list[Path],
+        dest: str | Path,
+        base_dir: str | Path | None = None,
+    ) -> tuple[list[Path], list[Path]]:
+        """フォルダ構造のみ作成し, 対応するパスを返す.
+
+        ファイルの中身はコピーせず, 出力先のフォルダ構造だけを作成する.
+        処理後のファイルを元と同じ構造で保存したい場合に便利.
+
+        Args:
+            files: 対象のファイルリスト.
+            dest: 出力先ディレクトリ.
+            base_dir: 階層構造の基準ディレクトリ.
+
+        Returns:
+            (元ファイルパスリスト, 出力先ファイルパスリスト) のタプル.
+
+        Examples:
+            >>> pochi = Pochi()
+            >>> files = pochi.find_files("data/", pattern="**/*.jpg")
+            >>> src_files, dest_files = pochi.mirror_structure(
+            ...     files, dest="processed/", base_dir="data/"
+            ... )
+            >>> for src, dst in zip(src_files, dest_files):
+            ...     result = process(src)
+            ...     result.save(dst)
+        """
+        return self._file_copier.mirror_structure(files, dest, base_dir=base_dir)


### PR DESCRIPTION
## Summary

- `IFileCopier` に `mirror_structure` メソッドを追加
- ファイルの中身をコピーせず, フォルダ構造のみ作成
- 元ファイルと出力先ファイルの対応パスを返す

## 使用例

```python
from pochi import Pochi

pochi = Pochi()

# ファイルを検索
files = pochi.find_files("data/", pattern="**/*.jpg")

# フォルダ構造のみ作成 + 対応パスを取得
src_files, dest_files = pochi.mirror_structure(
    files, dest="processed/", base_dir="data/"
)
# 結果: processed/train/cat/, processed/train/dog/ が作成される
#       src_files = [Path("data/train/cat/001.jpg"), ...]
#       dest_files = [Path("processed/train/cat/001.jpg"), ...]

# 元ファイルを処理して, 対応する保存先に出力
for src, dst in zip(src_files, dest_files):
    result = process(src)
    result.save(dst)
```

## 変更内容

- `pochi/fileops/interfaces.py`: `IFileCopier` に抽象メソッド追加
- `pochi/fileops/copier.py`: `StructurePreservingCopier` に実装追加
- `pochi/pochi.py`: ファサードに `mirror_structure` メソッド追加
- `tests/test_fileops.py`: テストを追加

## Test plan

- [x] pre-commit 全パス (black, isort, mypy, pydocstyle, pytest)
- [x] フォルダ構造が作成されることを確認
- [x] ファイルがコピーされないことを確認
- [x] 対応パスが正しく返されることを確認