### PR TITLE
fix: ロガー名プレフィックスの二重付与を防止

### DIFF
--- a/pochi/logging/factory.py
+++ b/pochi/logging/factory.py
@@ -40,8 +40,11 @@ class LoggerFactory(ILoggerFactory):
         Returns:
             設定済みのロガー.
         """
-        # プレフィックス付きのロガー名を生成
-        logger_name = f"{self._PREFIX}{name}"
+        # プレフィックス付きのロガー名を生成（二重付与を防止）
+        if name.startswith(self._PREFIX):
+            logger_name = name
+        else:
+            logger_name = f"{self._PREFIX}{name}"
 
         # キャッシュキーを生成
         cache_key = f"{logger_name}:{log_dir}"

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -119,6 +119,16 @@ class TestLoggerFactory:
 
         assert logger1 is logger2
 
+    def test_prefix_not_duplicated(self) -> None:
+        """pochi. プレフィックスが二重付与されないことを確認."""
+        factory = LoggerFactory()
+
+        # pochi. で始まる名前を渡す
+        logger = factory.create("pochi.mymodule")
+
+        # pochi.pochi.mymodule ではなく pochi.mymodule になる
+        assert logger.name == "pochi.mymodule"
+
 
 class TestPochiGetLogger:
     """Pochi.get_loggerメソッドのテスト."""


### PR DESCRIPTION
## Summary

- `LoggerFactory` で `pochi.` プレフィックスが二重付与されるのを防止
- `pochi.mymodule` を渡すと `pochi.pochi.mymodule` になる問題を修正

## 変更内容

- `pochi/logging/factory.py`: プレフィックス付与前にチェックを追加
- `tests/test_logging.py`: テストを追加

## Test plan

- [x] pre-commit 全パス
- [x] `pochi.` で始まる名前でも正しく動作することを確認