### PR TITLE
feat: 汎用クラスレジストリ機能を追加

### DIFF
--- a/pochi/registry/__init__.py
+++ b/pochi/registry/__init__.py
@@ -1,0 +1,6 @@
+"""レジストリモジュール."""
+
+from .interfaces import IRegistry
+from .registry import Registry
+
+__all__ = ["IRegistry", "Registry"]

--- a/pochi/registry/interfaces.py
+++ b/pochi/registry/interfaces.py
@@ -1,0 +1,82 @@
+"""レジストリのインターフェース定義."""
+
+from abc import ABC, abstractmethod
+from typing import Any, Callable
+
+
+class IRegistry(ABC):
+    """クラスレジストリの抽象基底クラス.
+
+    デコレータベースでクラスを登録し, 名前から動的にインスタンス生成する.
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """レジストリ名を返す."""
+        pass
+
+    @abstractmethod
+    def __contains__(self, name: str) -> bool:
+        """名前が登録済みかチェックする.
+
+        Args:
+            name: 登録名.
+
+        Returns:
+            登録済みならTrue.
+        """
+        pass
+
+    @abstractmethod
+    def register(self, name: str) -> Callable[[type], type]:
+        """クラス登録デコレータを返す.
+
+        Args:
+            name: 登録名.
+
+        Returns:
+            デコレータ関数.
+        """
+        pass
+
+    @abstractmethod
+    def create(self, name: str, **kwargs: Any) -> Any:
+        """名前からインスタンスを生成する.
+
+        Args:
+            name: 登録名.
+            **kwargs: コンストラクタに渡す引数.
+
+        Returns:
+            生成されたインスタンス.
+
+        Raises:
+            ValueError: 未登録の名前が指定された場合.
+        """
+        pass
+
+    @abstractmethod
+    def keys(self) -> list[str]:
+        """登録済みの名前一覧を返す.
+
+        Returns:
+            登録名のリスト.
+        """
+        pass
+
+    @abstractmethod
+    def create_from_config(self, config_list: "list[dict[str, Any]]") -> "list[Any]":
+        """設定リストから複数インスタンスを一括生成する.
+
+        Args:
+            config_list: 設定dictのリスト. 各dictには "name" キーが必須.
+
+        Returns:
+            生成されたインスタンスのリスト.
+
+        Raises:
+            ValueError: 未登録の名前が指定された場合.
+            KeyError: "name" キーが存在しない場合.
+        """
+        pass

--- a/pochi/registry/registry.py
+++ b/pochi/registry/registry.py
@@ -1,0 +1,161 @@
+"""汎用クラスレジストリの実装."""
+
+from typing import Any, Callable
+
+from .interfaces import IRegistry
+
+
+class Registry(IRegistry):
+    """汎用クラスレジストリ.
+
+    デコレータベースでクラスを登録し, 設定ファイルから動的にインスタンス生成できる.
+
+    Args:
+        name: レジストリ名（識別用）.
+
+    Examples:
+        >>> registry = Registry("processors")
+        >>> @registry.register("blur")
+        ... class BlurProcessor:
+        ...     def __init__(self, kernel_size: int = 5):
+        ...         self.kernel_size = kernel_size
+        >>> blur = registry.create("blur", kernel_size=7)
+        >>> blur.kernel_size
+        7
+    """
+
+    def __init__(self, name: str) -> None:
+        """Registryを初期化."""
+        self._name = name
+        self._registry: dict[str, type] = {}
+
+    @property
+    def name(self) -> str:
+        """レジストリ名を返す."""
+        return self._name
+
+    def register(self, name: str) -> Callable[[type], type]:
+        """クラス登録デコレータを返す.
+
+        Args:
+            name: 登録名.
+
+        Returns:
+            デコレータ関数.
+
+        Raises:
+            ValueError: 同じ名前が既に登録されている場合.
+
+        Examples:
+            >>> registry = Registry("models")
+            >>> @registry.register("resnet")
+            ... class ResNet:
+            ...     pass
+        """
+
+        def decorator(cls: type) -> type:
+            if name in self._registry:
+                raise ValueError(
+                    f"'{name}' は既に登録されています: {self._registry[name]}"
+                )
+            self._registry[name] = cls
+            return cls
+
+        return decorator
+
+    def create(self, name: str, **kwargs: Any) -> Any:
+        """名前からインスタンスを生成する.
+
+        Args:
+            name: 登録名.
+            **kwargs: コンストラクタに渡す引数.
+
+        Returns:
+            生成されたインスタンス.
+
+        Raises:
+            ValueError: 未登録の名前が指定された場合.
+
+        Examples:
+            >>> registry = Registry("processors")
+            >>> @registry.register("blur")
+            ... class Blur:
+            ...     def __init__(self, size: int = 3):
+            ...         self.size = size
+            >>> blur = registry.create("blur", size=5)
+        """
+        if name not in self._registry:
+            available = self.keys()
+            raise ValueError(f"未登録: '{name}'. 利用可能: {available}")
+        return self._registry[name](**kwargs)
+
+    def keys(self) -> list[str]:
+        """登録済みの名前一覧を返す.
+
+        Returns:
+            登録名のリスト.
+
+        Examples:
+            >>> registry = Registry("models")
+            >>> @registry.register("a")
+            ... class A: pass
+            >>> @registry.register("b")
+            ... class B: pass
+            >>> registry.keys()
+            ['a', 'b']
+        """
+        return list(self._registry.keys())
+
+    def create_from_config(self, config_list: list[dict[str, Any]]) -> list[Any]:
+        """設定リストから複数インスタンスを一括生成する.
+
+        Args:
+            config_list: 設定dictのリスト. 各dictには "name" キーが必須.
+
+        Returns:
+            生成されたインスタンスのリスト.
+
+        Raises:
+            ValueError: 未登録の名前が指定された場合.
+            KeyError: "name" キーが存在しない場合.
+
+        Examples:
+            >>> registry = Registry("processors")
+            >>> @registry.register("blur")
+            ... class Blur:
+            ...     def __init__(self, size: int = 3):
+            ...         self.size = size
+            >>> @registry.register("edge")
+            ... class Edge:
+            ...     def __init__(self, threshold: int = 100):
+            ...         self.threshold = threshold
+            >>> config = [
+            ...     {"name": "blur", "size": 5},
+            ...     {"name": "edge", "threshold": 50},
+            ... ]
+            >>> instances = registry.create_from_config(config)
+        """
+        result = []
+        for step in config_list:
+            if "name" not in step:
+                raise KeyError("設定には 'name' キーが必要です")
+            name = step["name"]
+            kwargs = {k: v for k, v in step.items() if k != "name"}
+            instance = self.create(name, **kwargs)
+            result.append(instance)
+        return result
+
+    def __contains__(self, name: str) -> bool:
+        """名前が登録済みかチェックする.
+
+        Args:
+            name: 登録名.
+
+        Returns:
+            登録済みならTrue.
+        """
+        return name in self._registry
+
+    def __len__(self) -> int:
+        """登録済みクラス数を返す."""
+        return len(self._registry)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,242 @@
+"""Tests for Registry functionality."""
+
+import pytest
+
+from pochi import Pochi
+from pochi.registry import IRegistry, Registry
+
+
+class TestRegistry:
+    """Registryクラスのテスト."""
+
+    def test_register_and_create(self) -> None:
+        """クラスを登録してインスタンス生成できることを確認."""
+        registry = Registry("test")
+
+        @registry.register("sample")
+        class Sample:
+            def __init__(self, value: int = 0):
+                self.value = value
+
+        instance = registry.create("sample", value=42)
+
+        assert instance.value == 42
+
+    def test_register_without_args(self) -> None:
+        """引数なしでインスタンス生成できることを確認."""
+        registry = Registry("test")
+
+        @registry.register("simple")
+        class Simple:
+            pass
+
+        instance = registry.create("simple")
+
+        assert isinstance(instance, Simple)
+
+    def test_keys_returns_registered_names(self) -> None:
+        """登録済み名前一覧が取得できることを確認."""
+        registry = Registry("test")
+
+        @registry.register("a")
+        class A:
+            pass
+
+        @registry.register("b")
+        class B:
+            pass
+
+        names = registry.keys()
+
+        assert "a" in names
+        assert "b" in names
+        assert len(names) == 2
+
+    def test_create_unregistered_raises_error(self) -> None:
+        """未登録名でcreateするとValueErrorが発生することを確認."""
+        registry = Registry("test")
+
+        with pytest.raises(ValueError) as exc_info:
+            registry.create("unknown")
+
+        assert "未登録" in str(exc_info.value)
+        assert "unknown" in str(exc_info.value)
+
+    def test_duplicate_register_raises_error(self) -> None:
+        """同じ名前で二重登録するとValueErrorが発生することを確認."""
+        registry = Registry("test")
+
+        @registry.register("dup")
+        class First:
+            pass
+
+        with pytest.raises(ValueError) as exc_info:
+
+            @registry.register("dup")
+            class Second:
+                pass
+
+        assert "既に登録されています" in str(exc_info.value)
+
+    def test_name_property(self) -> None:
+        """レジストリ名が取得できることを確認."""
+        registry = Registry("my_registry")
+
+        assert registry.name == "my_registry"
+
+    def test_contains(self) -> None:
+        """in演算子で登録済みかチェックできることを確認."""
+        registry = Registry("test")
+
+        @registry.register("exists")
+        class Exists:
+            pass
+
+        assert "exists" in registry
+        assert "not_exists" not in registry
+
+    def test_len(self) -> None:
+        """len()で登録数が取得できることを確認."""
+        registry = Registry("test")
+
+        assert len(registry) == 0
+
+        @registry.register("a")
+        class A:
+            pass
+
+        assert len(registry) == 1
+
+        @registry.register("b")
+        class B:
+            pass
+
+        assert len(registry) == 2
+
+
+class TestRegistryCreateFromConfig:
+    """Registry.create_from_configメソッドのテスト."""
+
+    def test_create_from_config(self) -> None:
+        """設定リストから一括生成できることを確認."""
+        registry = Registry("processors")
+
+        @registry.register("blur")
+        class Blur:
+            def __init__(self, size: int = 3):
+                self.size = size
+
+        @registry.register("edge")
+        class Edge:
+            def __init__(self, threshold: int = 100):
+                self.threshold = threshold
+
+        config = [
+            {"name": "blur", "size": 5},
+            {"name": "edge", "threshold": 50},
+        ]
+
+        instances = registry.create_from_config(config)
+
+        assert len(instances) == 2
+        assert instances[0].size == 5
+        assert instances[1].threshold == 50
+
+    def test_create_from_config_empty_list(self) -> None:
+        """空リストで空の結果が返ることを確認."""
+        registry = Registry("test")
+
+        instances = registry.create_from_config([])
+
+        assert instances == []
+
+    def test_create_from_config_without_name_raises_error(self) -> None:
+        """nameキーがないとKeyErrorが発生することを確認."""
+        registry = Registry("test")
+
+        @registry.register("sample")
+        class Sample:
+            pass
+
+        with pytest.raises(KeyError) as exc_info:
+            registry.create_from_config([{"value": 1}])
+
+        assert "name" in str(exc_info.value)
+
+    def test_create_from_config_unregistered_raises_error(self) -> None:
+        """未登録名が含まれるとValueErrorが発生することを確認."""
+        registry = Registry("test")
+
+        with pytest.raises(ValueError) as exc_info:
+            registry.create_from_config([{"name": "unknown"}])
+
+        assert "未登録" in str(exc_info.value)
+
+
+class TestPochiCreateRegistry:
+    """Pochi.create_registryメソッドのテスト."""
+
+    def test_create_registry_returns_registry(self) -> None:
+        """Registryインスタンスが返されることを確認."""
+        pochi = Pochi()
+
+        registry = pochi.create_registry("models")
+
+        assert isinstance(registry, IRegistry)
+        assert registry.name == "models"
+
+    def test_create_registry_is_independent(self) -> None:
+        """複数のレジストリが独立していることを確認."""
+        pochi = Pochi()
+
+        registry1 = pochi.create_registry("models")
+        registry2 = pochi.create_registry("losses")
+
+        @registry1.register("resnet")
+        class ResNet:
+            pass
+
+        @registry2.register("dice")
+        class DiceLoss:
+            pass
+
+        assert "resnet" in registry1
+        assert "resnet" not in registry2
+        assert "dice" in registry2
+        assert "dice" not in registry1
+
+    def test_full_workflow(self) -> None:
+        """Pochiからの完全なワークフローを確認."""
+        pochi = Pochi()
+        processors = pochi.create_registry("processors")
+
+        @processors.register("blur")
+        class BlurProcessor:
+            def __init__(self, kernel_size: int = 5):
+                self.kernel_size = kernel_size
+
+            def process(self, x: int) -> int:
+                return x * self.kernel_size
+
+        @processors.register("scale")
+        class ScaleProcessor:
+            def __init__(self, factor: int = 2):
+                self.factor = factor
+
+            def process(self, x: int) -> int:
+                return x * self.factor
+
+        config = [
+            {"name": "blur", "kernel_size": 3},
+            {"name": "scale", "factor": 10},
+        ]
+
+        pipeline = processors.create_from_config(config)
+
+        # パイプライン実行
+        value = 1
+        for proc in pipeline:
+            value = proc.process(value)
+
+        # 1 * 3 * 10 = 30
+        assert value == 30


### PR DESCRIPTION
## Summary

- 汎用クラスレジストリ機能を追加
- デコレータベースでクラスを登録し, 設定ファイルから動的にインスタンス生成可能
- `pochi.create_registry()` で簡単にレジストリを作成

## 使用例

```python
from pochi import Pochi

pochi = Pochi()

# レジストリ作成
processors = pochi.create_registry("processors")

# デコレータで登録
@processors.register("blur")
class BlurProcessor:
    def __init__(self, kernel_size: int = 5):
        self.kernel_size = kernel_size

    def process(self, image):
        ...

@processors.register("edge")
class EdgeProcessor:
    def __init__(self, threshold: int = 100):
        self.threshold = threshold

    def process(self, image):
        ...

# 単体生成
blur = processors.create("blur", kernel_size=7)

# 登録一覧
processors.keys()  # ["blur", "edge"]

# 設定ファイルから一括生成
config = pochi.load_config("config.yaml")
pipeline = processors.create_from_config(config["pipeline"])
```

## 変更内容

- `pochi/registry/` モジュールを新規追加
  - `IRegistry` インターフェース
  - `Registry` 実装クラス
- `Pochi.create_registry()` メソッドを追加
- テストを追加

## Test plan

- [x] クラス登録とインスタンス生成
- [x] 登録済み名前一覧取得
- [x] 設定リストからの一括生成
- [x] 未登録名へのアクセス時のエラー
- [x] 二重登録時のエラー
- [x] Pochiからの完全なワークフロー