### PR TITLE
docs: READMEにバッジと新機能ドキュメントを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # pochimethod
 
+[![Python](https://img.shields.io/badge/Python-3.13%2B-blue?logo=python&logoColor=white)](https://www.python.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+
 Pythonのための便利メソッド集 — ポチのお気に入りの骨、全部ここに！
 
 ## インストール
@@ -85,6 +89,54 @@ result = pochi.copy_files("data/", "backup/", pattern="**/*.jpg")
 
 # 移動も同様
 result = pochi.move_files("temp/", "archive/", pattern="**/*.log")
+```
+
+### Image
+
+アスペクト比を保持して画像をリサイズし、足りない部分をパディングで埋めます。CNN学習用データセットの前処理に便利です。
+
+```python
+# 画像を検索
+files = pochi.find_files("data/train", extensions=[".jpg", ".png"])
+
+# フォルダ構造をミラーリング
+src_files, dst_files = pochi.mirror_structure(
+    files, dest="data_resized/train", base_dir="data/train"
+)
+
+# アスペクト比を保持して 224x224 にリサイズ
+for src, dst in zip(src_files, dst_files):
+    pochi.resize_image(src, dst, size=224)
+```
+
+### Registry
+
+デコレータベースでクラスを登録し、設定ファイルから動的にインスタンスを生成します。
+
+```python
+# レジストリを作成
+processors = pochi.create_registry("processors")
+
+# クラスを登録
+@processors.register("blur")
+class BlurProcessor:
+    def __init__(self, kernel_size: int = 5):
+        self.kernel_size = kernel_size
+
+@processors.register("edge")
+class EdgeProcessor:
+    def __init__(self, threshold: int = 100):
+        self.threshold = threshold
+
+# 名前から生成
+blur = processors.create("blur", kernel_size=7)
+
+# 設定リストから一括生成
+config = [
+    {"name": "blur", "kernel_size": 7},
+    {"name": "edge", "threshold": 50},
+]
+pipeline = processors.create_from_config(config)
 ```
 
 ### Timer


### PR DESCRIPTION
## Summary

- Python 3.13+, MIT License, Black のバッジを追加
- Image (resize_image) セクションを追加
- Registry (create_registry) セクションを追加

## 変更内容

- README.md にバッジを追加
  - Python バージョン
  - ライセンス
  - コードスタイル (Black)
- 新機能のドキュメントを追加
  - Image: アスペクト比保持リサイズ機能
  - Registry: クラスレジストリ機能

## Test plan

- [x] バッジが正しく表示されることを確認
- [x] 各セクションのコード例が正しいことを確認