### PR TITLE
chore: GitHub Issue/PR テンプレートを追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+labels: bug
+---
+
+## Summary
+
+<!-- A clear and concise description of the bug. -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+<!-- What you expected to happen. -->
+
+## Actual Behavior
+
+<!-- What actually happened. -->
+
+## Environment
+
+- OS:
+- Runtime:
+- Version:
+
+## Additional Context
+
+<!-- Screenshots, logs, or any other relevant information. -->
+
+---
+
+> **Branch prefix**: `fix/`

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/documentation_request.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request.md
@@ -1,0 +1,25 @@
+---
+name: Documentation Request
+about: Request new or improved documentation
+labels: documentation
+---
+
+## Summary
+
+<!-- Brief description of the documentation improvement. -->
+
+## Target Documents
+
+<!-- Which files or sections need to be updated? -->
+
+## Proposed Changes
+
+<!-- What should be added, changed, or clarified? -->
+
+## Acceptance Criteria
+
+- [ ]
+
+---
+
+> **Branch prefix**: `docs/`

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,33 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement
+labels: enhancement
+---
+
+## Summary
+
+<!-- Brief description of the feature. -->
+
+## Background
+
+<!-- Why is this feature needed? What problem does it solve? -->
+
+## Scope
+
+<!-- What should be included in the implementation? -->
+
+## Out of Scope
+
+<!-- What is explicitly NOT included? -->
+
+## Acceptance Criteria
+
+- [ ]
+
+## Additional Context
+
+<!-- Any other context, references, or screenshots. -->
+
+---
+
+> **Branch prefix**: `feature/`

--- a/.github/ISSUE_TEMPLATE/refactor_request.md
+++ b/.github/ISSUE_TEMPLATE/refactor_request.md
@@ -1,0 +1,29 @@
+---
+name: Refactor Request
+about: Propose a code refactoring
+labels: refactoring
+---
+
+## Summary
+
+<!-- Brief description of the refactoring. -->
+
+## Background
+
+<!-- Why is this refactoring needed? -->
+
+## Current Implementation
+
+<!-- What are the problems with the current code? -->
+
+## Proposed Changes
+
+<!-- What changes do you propose? -->
+
+## Acceptance Criteria
+
+- [ ]
+
+---
+
+> **Branch prefix**: `refactor/`

--- a/.github/ISSUE_TEMPLATE/test_request.md
+++ b/.github/ISSUE_TEMPLATE/test_request.md
@@ -1,0 +1,25 @@
+---
+name: Test Request
+about: Request new or improved tests
+labels: test
+---
+
+## Summary
+
+<!-- Brief description of the test improvement. -->
+
+## Target Code
+
+<!-- Which modules or functions need test coverage? -->
+
+## Test Cases
+
+<!-- What test cases should be added or improved? -->
+
+## Acceptance Criteria
+
+- [ ]
+
+---
+
+> **Branch prefix**: `test/`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Summary
+
+<!-- Brief description of what this PR does. -->
+
+-
+
+## Related Issue
+
+<!-- Link the related issue. Use `Closes #XX` to auto-close on merge. -->
+
+Closes #
+
+## Changes
+
+<!-- List the main changes. -->
+
+-
+
+## Test Plan
+
+- [ ]
+
+## Checklist
+
+- [ ]


### PR DESCRIPTION
## Summary

- GitHub Issue テンプレートと PR テンプレートを追加

## Related Issue

なし

## Changes

- `.github/ISSUE_TEMPLATE/` に5種類の Issue テンプレートを追加
  - `bug_report.md` — バグ報告 (`bug` ラベル, `fix/` ブランチ)
  - `feature_request.md` — 機能リクエスト (`enhancement` ラベル, `feature/` ブランチ)
  - `documentation_request.md` — ドキュメント改善 (`documentation` ラベル, `docs/` ブランチ)
  - `refactor_request.md` — リファクタリング (`refactoring` ラベル, `refactor/` ブランチ)
  - `test_request.md` — テスト追加・改善 (`test` ラベル, `test/` ブランチ)
- `.github/ISSUE_TEMPLATE/config.yml` で空の Issue 作成を許可
- `.github/pull_request_template.md` に PR テンプレートを追加

## Test plan

- [x] 各テンプレートファイルが正しいフロントマター形式であることを確認
- [x] GitHub の Issue 作成画面でテンプレート選択肢が表示されることを確認
- [x] PR 作成時にテンプレートが自動適用されることを確認