### PR TITLE
chore: CHANGELOG とアーカイブ構成を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- Workspace に `__dir__` を追加し IDE 補完を改善 ([#22](https://github.com/kurorosu/pochimethod/pull/22))
+- TimerContext で例外発生時に warning ログを出力 ([#23](https://github.com/kurorosu/pochimethod/pull/23))
+- JsonConfigLoader, YamlConfigLoader を追加 ([#24](https://github.com/kurorosu/pochimethod/pull/24))
+- `mirror_structure` メソッドを追加 ([#25](https://github.com/kurorosu/pochimethod/pull/25))
+- 汎用クラスレジストリ機能を追加 ([#29](https://github.com/kurorosu/pochimethod/pull/29))
+- `create_workspace` に `prefix` 引数を追加して連番ディレクトリ生成に対応 ([#31](https://github.com/kurorosu/pochimethod/pull/31))
+- アスペクト比保持リサイズ機能を追加 ([#35](https://github.com/kurorosu/pochimethod/pull/35))
+- GitHub Issue/PR テンプレートを追加 ([#37](https://github.com/kurorosu/pochimethod/pull/37))
+
+### Changed
+
+- README にバッジと新機能ドキュメントを追加 ([#36](https://github.com/kurorosu/pochimethod/pull/36))
+
+### Fixed
+
+- ロガー名プレフィックスの二重付与を防止 ([#27](https://github.com/kurorosu/pochimethod/pull/27))
+
+## [0.0.2] - 2025-12-31
+
+### Added
+
+- `IConfigLoader` インターフェースを追加 ([#6](https://github.com/kurorosu/pochimethod/pull/6))
+- `PythonConfigLoader` を実装, strict モードをデフォルトに設定 ([#6](https://github.com/kurorosu/pochimethod/pull/6))
+- `Pochi` クラスに `load_config` メソッドを追加 ([#6](https://github.com/kurorosu/pochimethod/pull/6))
+- `IFileFinder`, `IFileCopier` インターフェースを追加 ([#8](https://github.com/kurorosu/pochimethod/pull/8))
+- `GlobFileFinder`, `StructurePreservingCopier` を実装 ([#8](https://github.com/kurorosu/pochimethod/pull/8))
+- `Pochi` クラスに `find_files`, `copy_files`, `move_files` を追加 ([#8](https://github.com/kurorosu/pochimethod/pull/8))
+
+### Changed
+
+- `__all__` を `Pochi` のみに変更し学習コストを低減 ([#6](https://github.com/kurorosu/pochimethod/pull/6))
+- README に FileOps セクションを追加 ([#21](https://github.com/kurorosu/pochimethod/pull/21))
+- PythonConfigLoader のセキュリティ警告を追加 ([#17](https://github.com/kurorosu/pochimethod/pull/17))
+
+### Fixed
+
+- ロガー名に `pochi.` プレフィックスを追加し他ライブラリとの衝突を防止 ([#18](https://github.com/kurorosu/pochimethod/pull/18))
+- FileHandler 作成前にログディレクトリを自動作成 ([#19](https://github.com/kurorosu/pochimethod/pull/19))
+- PythonConfigLoader のモジュール名をファイル名から生成 ([#20](https://github.com/kurorosu/pochimethod/pull/20))
+
+## Archived Changelogs
+
+Older version histories are archived in the [`changelogs/`](changelogs/) directory.

--- a/changelogs/0.0.x.md
+++ b/changelogs/0.0.x.md
@@ -1,0 +1,12 @@
+# 0.0.x
+
+## [0.0.1] - 2025-12-30
+
+### Added
+
+- プロジェクト初期化 (uv 環境, Python 3.13 開発ツール)
+- `Pochi` クラスに `mkdir` メソッドを追加 ([#1](https://github.com/kurorosu/pochimethod/pull/1))
+- `create_workspace` メソッドでタイムスタンプ付きワークスペースを作成 ([#1](https://github.com/kurorosu/pochimethod/pull/1))
+- `get_logger` メソッドで Workspace 連携ロガーを追加 ([#2](https://github.com/kurorosu/pochimethod/pull/2))
+- `timer` メソッドで処理時間計測コンテキストマネージャーを追加 ([#3](https://github.com/kurorosu/pochimethod/pull/3))
+- PyPI 公開用メタデータを追加 ([#4](https://github.com/kurorosu/pochimethod/pull/4))

--- a/changelogs/README.md
+++ b/changelogs/README.md
@@ -1,0 +1,18 @@
+# Archived Changelogs
+
+This directory contains archived changelog entries for older versions.
+
+When the main `CHANGELOG.md` grows too long, move completed version entries here grouped by minor version series.
+
+## Files
+
+| File | Versions |
+|---|---|
+| `0.0.x.md` | 0.0.1 - 0.0.x |
+
+## How to Archive
+
+1. Cut the version entries from `CHANGELOG.md` (keep `[Unreleased]` and the latest release)
+2. Create a new file named `X.Y.x.md` (e.g. `1.3.x.md`)
+3. Paste the entries into the new file
+4. Update the table above


### PR DESCRIPTION
## Summary

- CHANGELOG.md と changelogs/ アーカイブ構成を追加

## Related Issue

無し

## Changes

- `CHANGELOG.md` を追加 (Keep a Changelog 形式)
  - v0.0.1, v0.0.2 の全履歴と Unreleased セクションを記載
  - PR 番号を GitHub リンク付きで記載
- `changelogs/README.md` を追加 (アーカイブ運用ガイド)
- `changelogs/0.0.x.md` に v0.0.1 のエントリをアーカイブ

## Test plan

- [x] CHANGELOG.md が Keep a Changelog 形式に準拠していることを確認
- [x] PR リンクが正しい URL であることを確認
- [x] changelogs/0.0.x.md に v0.0.1 エントリが正しくアーカイブされていることを確認