### PR TITLE
docs: Image リサイズのサンプルコードを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,4 @@ tmp*.*
 CLAUDE.md
 .vscode
 outputs/
+examples/image/data_resized/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `create_workspace` に `prefix` 引数を追加して連番ディレクトリ生成に対応 ([#31](https://github.com/kurorosu/pochimethod/pull/31))
 - アスペクト比保持リサイズ機能を追加 ([#35](https://github.com/kurorosu/pochimethod/pull/35))
 - GitHub Issue/PR テンプレートを追加 ([#37](https://github.com/kurorosu/pochimethod/pull/37))
+- Image リサイズのサンプルコード `examples/image/resize_with_padding.py` を追加
 
 ### Changed
 
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - ロガー名プレフィックスの二重付与を防止 ([#27](https://github.com/kurorosu/pochimethod/pull/27))
+- リサイズ時の 1px ズレを `round()` + クランプで修正
 
 ## [0.0.2] - 2025-12-31
 

--- a/examples/image/resize_with_padding.py
+++ b/examples/image/resize_with_padding.py
@@ -1,0 +1,54 @@
+"""アスペクト比を保持した画像リサイズのサンプル.
+
+フォルダ構造を維持しながら, 画像を指定サイズにパディングリサイズします.
+CNN学習用データセットの前処理に便利です.
+
+使い方:
+    uv run python examples/image/resize_with_padding.py
+
+入力フォルダ構造の例:
+    examples/image/data/train/
+    ├── cat/
+    │   ├── 001.jpg
+    │   └── 002.jpg
+    └── dog/
+        ├── 001.jpg
+        └── 002.jpg
+
+出力フォルダ構造:
+    examples/image/data_resized/train/
+    ├── cat/
+    │   ├── 001.jpg   (640x640, パディング付き)
+    │   └── 002.jpg
+    └── dog/
+        ├── 001.jpg
+        └── 002.jpg
+"""
+
+from pathlib import Path
+
+from pochi import Pochi
+
+# ===== 設定 =====
+EXAMPLE_DIR = Path(__file__).parent
+SRC_DIR = EXAMPLE_DIR / "data" / "train"
+DST_DIR = EXAMPLE_DIR / "data_resized" / "train"
+TARGET_SIZE = 640  # 正方形の場合は int, 矩形の場合は (width, height)
+EXTENSIONS = [".jpg", ".jpeg", ".png", ".bmp", ".tiff"]
+
+# ===== 実行 =====
+pochi = Pochi()
+
+# 1. 画像ファイルを検索
+files = pochi.find_files(SRC_DIR, extensions=EXTENSIONS)
+print(f"検出した画像: {len(files)} 枚")
+
+# 2. フォルダ構造をミラーリング (ファイルはコピーしない)
+src_files, dst_files = pochi.mirror_structure(files, dest=DST_DIR, base_dir=SRC_DIR)
+
+# 3. アスペクト比を保持してリサイズ
+for src, dst in zip(src_files, dst_files):
+    pochi.resize_image(src, dst, size=TARGET_SIZE, mode="long", padding_color=(0, 0, 0))
+    print(f"  {src} -> {dst}")
+
+print(f"完了: {len(src_files)} 枚をリサイズしました")

--- a/pochi/image/resizer.py
+++ b/pochi/image/resizer.py
@@ -75,8 +75,12 @@ def resize_with_padding(
         # 短辺を基準: 短辺を合わせる（はみ出しはクロップ）
         ratio = max(target_w / orig_w, target_h / orig_h)
 
-    new_w = int(orig_w * ratio)
-    new_h = int(orig_h * ratio)
+    if mode == "long":
+        new_w = min(round(orig_w * ratio), target_w)
+        new_h = min(round(orig_h * ratio), target_h)
+    else:
+        new_w = max(round(orig_w * ratio), target_w)
+        new_h = max(round(orig_h * ratio), target_h)
     img_resized = img.resize((new_w, new_h), Image.LANCZOS)
 
     # 結果画像を作成


### PR DESCRIPTION
## Summary

- `examples/image/` にパディングリサイズのサンプルコードを追加
- リサイズ時の 1px ズレを修正

## Related Issue

無し

## Changes

- `examples/image/resize_with_padding.py` を追加
  - `find_files` → `mirror_structure` → `resize_image` の3ステップワークフロー
  - フォルダ構造を保持しながらアスペクト比保持リサイズ
- `examples/image/data/train/.gitkeep` でサンプル入力フォルダを追跡
- `.gitignore` に `examples/image/data_resized/` を追加
- `pochi/image/resizer.py` のリサイズサイズ計算を `int()` → `round()` + クランプに修正
  - `mode="long"`: `min(round(...), target)` でターゲット超過を防止
  - `mode="short"`: `max(round(...), target)` でターゲット未達を防止

## Test plan

- [x] `uv run pytest tests/test_image.py` が全テスト通過することを確認
- [x] サンプルコードが正しい Python 構文であることを確認
- [x] `.gitignore` に出力ディレクトリが含まれていることを確認